### PR TITLE
Wrong project name is fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.example</groupId>
-    <artifactId>EU8G9_Centrilli</artifactId>
+    <artifactId>Centrilli-EU8G9</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.example</groupId>
+    <groupId>com.centrilli</groupId>
     <artifactId>Centrilli-EU8G9</artifactId>
     <version>1.0-SNAPSHOT</version>
 


### PR DESCRIPTION
The name given for project when framework was being created was causing the display of wrong name in IDEs, because it is determined by artifactID in pom.xml. Matching it with repository name fixed the issue.

Those who are still having the issue, which is about the IDE itself and not the code, should refactor their project folder and name it repository's name.

![pr_1](https://user-images.githubusercontent.com/47505856/177631080-3761a47d-bca5-4862-ad06-a81df9aeba1e.png)
![pr_2](https://user-images.githubusercontent.com/47505856/177631087-ec6eaf10-b6cb-45f9-89f2-765b2cf623aa.png)

Those who clone later will not have this problem.

