### PR TITLE
Fix: duplicate step definition exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.example</groupId>
-    <artifactId>EU8G9_Centrilli</artifactId>
+    <artifactId>Centrilli-EU8G9</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.example</groupId>
+    <groupId>com.centrilli</groupId>
     <artifactId>Centrilli-EU8G9</artifactId>
     <version>1.0-SNAPSHOT</version>
 

--- a/src/test/java/com/centrilli/step_defs/CreateNewVehicle_StepDefinitions.java
+++ b/src/test/java/com/centrilli/step_defs/CreateNewVehicle_StepDefinitions.java
@@ -20,11 +20,7 @@ public class CreateNewVehicle_StepDefinitions {
     LoginPage loginPage = new LoginPage();
     WebDriverWait wait = new WebDriverWait(Driver.getDriver(), 10);
 
-    @Given("user is already logged in")
-    public void user_is_already_logged_in() {
-      loginPage.login();
 
-    }
     @Given("user clicks fleet module")
     public void user_clicks_fleet_module() {
     VehiclePages.moreOptionDropdown.click();

--- a/src/test/java/com/centrilli/step_defs/Employees_StepDefs.java
+++ b/src/test/java/com/centrilli/step_defs/Employees_StepDefs.java
@@ -22,11 +22,6 @@ public class Employees_StepDefs {
     private final String employeeName = new Faker().name().name();
 
 
-    @Given("user is logged in as PosManager")
-    public void user_is_logged_in_as_pos_manager() {
-        loginPage.login();
-    }
-
     @Given("user is on Employees page")
     public void user_is_on_employees_page() {
         employeesPage.btnNavigationEmployees.click();

--- a/src/test/java/com/centrilli/step_defs/Hooks.java
+++ b/src/test/java/com/centrilli/step_defs/Hooks.java
@@ -5,13 +5,16 @@ In the class we will be able to pass pre- & post- conditions to
  each scenario and each step
  */
 
+import com.centrilli.pages.LoginPage;
 import com.centrilli.utilities.Driver;
 import io.cucumber.java.After;
 import io.cucumber.java.Scenario;
+import io.cucumber.java.en.Given;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 
 public class Hooks {
+    LoginPage loginPage = new LoginPage();
 
     //import from io.cucumber.java not from junit
     //@Before (order = 1)
@@ -61,5 +64,9 @@ public class Hooks {
         System.out.println("--------> applying tearDown using @AfterStep");
     }
 
+    @Given("user is logged in as PosManager")
+    public void user_is_logged_in_as_pos_manager() {
+        loginPage.login();
+    }
 
 }


### PR DESCRIPTION
Duplicate methods for posmanager login was causing the error below:

`io.cucumber.core.runner.DuplicateStepDefinitionException: Duplicate step definitions in com.centrilli.step_defs.CreateNewVehicle_StepDefinitions.user_is_already_logged_in() and com.centrilli.step_defs.Calendar_StepDefs.user_is_already_logged_in()`

It turns out even without the error it is unnecessary to create different methods for the same purpose, because a feature file can detect methods from any step_definitions class. So I just put the method into Hooks class

When you need a posmanager login of Given annotation, just use this string:

`Given user is logged in as PosManager`

![pr_fix](https://user-images.githubusercontent.com/47505856/178561667-54fac645-105b-4126-bd86-3fc00d35cae5.png)

No additional method creation is needed, as it will be fetched from Hooks class